### PR TITLE
Adding badge for contributing from workspaces.openshift.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://workspaces.openshift.com#https://github.com/marcnuri-demo/jkube-remote-dev/)
+
 Eclipse JKube Remote Development Playground
 ===========================================
 


### PR DESCRIPTION
<img width="1713" alt="image" src="https://user-images.githubusercontent.com/1461122/216601537-0b6f99e3-2974-47c6-a808-2cf509b4b0fe.png">

Not fully functional. For some reason permission issue is hit during deployment

`Exception in thread "main" io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: DELETE at: https://172.30.0.1:443/apis/apps/v1/deployments/rabbit-mq. Message: Forbidden! User developer doesn't have permission. deployments.apps "rabbit-mq" is forbidden: User "ibuziuk" cannot delete resource "deployments" in API group "apps" at the cluster scope. `