### PR TITLE
feat: adding '.sdkmanrc' to the northwind module

### DIFF
--- a/northwind/.sdkmanrc
+++ b/northwind/.sdkmanrc
@@ -1,0 +1,4 @@
+# Run `sdk env` to use the SDKs below (c.f. sdkman env command)
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+java=17.0.3-tem


### PR DESCRIPTION
We need  '.sdkmanrc'  in the northwind module in order to use `workingDir: ${PROJECT_SOURCE}/northwind` for the commands defined in the devfile (otherwise java 17 is not picked up)