### PR TITLE
fix remove spring boot extention since java 17 is required

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-      "redhat.vscode-quarkus",
-      "pivotal.vscode-spring-boot"
+      "redhat.vscode-quarkus"
     ]
 }


### PR DESCRIPTION
![image](https://github.com/redhat-developer-demos/northwind-traders/assets/1461122/4597ab14-94b2-48a9-9f1a-331a8cb17823)

tried to make it work by adding dedicated env var, but this does not seem to work in 3.6:

```
components:
  - name: tools
    container:
      image: quay.io/devfile/universal-developer-image:ubi8-latest
      env:
        - name: QUARKUS_HTTP_HOST
          value: 0.0.0.0
      env:
       - name: USE_JAVA17
         value: "true"
```
