### PR TITLE
Removing postStart event

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -90,6 +90,3 @@ commands:
       commandLine: |
         oc delete all --selector 'group in (northwind-traders,northwind-industries)'
       workingDir: ${PROJECT_SOURCE}
-events:
-  postStart:
-    - package


### PR DESCRIPTION
Smth. is wrong with postStart events which result in workspace startup failure:

![image](https://github.com/redhat-developer-demos/northwind-traders/assets/1461122/ebdf759b-27b7-4918-9ef8-672d55278371)
